### PR TITLE
chore: Add missing configs example

### DIFF
--- a/configs.example.lua
+++ b/configs.example.lua
@@ -1,0 +1,10 @@
+local mod = {}
+
+mod.TOKEN_GLOBALS = {
+    Name = "",
+    Ticker = "",
+    Balances = {},
+    Denomination = 12,
+}
+
+return mod

--- a/src/token.lua
+++ b/src/token.lua
@@ -178,7 +178,7 @@ function mod:init(options)
     Validator
       :init({
         types = {
-          Sender = Type:string("Cannot transfer tokens. Recipient address must be a string."),
+          Sender = Type:string("Cannot transfer tokens. From address must be a string."),
           Recipient = Type:string("Cannot transfer tokens. Recipient address must be a string."),
         }
       })


### PR DESCRIPTION
## Summary

This PR adds missing `configs.example.lua` file.